### PR TITLE
fix initial lobby scrolling

### DIFF
--- a/app/components/chat-pane.js
+++ b/app/components/chat-pane.js
@@ -16,6 +16,10 @@ export default Ember.Component.extend({
         }, 500);
       } else {
         this.set('didInitialScroll', true);
+        // Set a timeout to do this again to fix a problem with Chrome rendering.
+        Ember.run.later(this, function () {
+          this.$().scrollTop(this.$().prop('scrollHeight'));
+        }, 400);
         this.$().scrollTop(this.$().prop('scrollHeight'));
       }
     });


### PR DESCRIPTION
"Fixes" https://github.com/SirZach/bbbbbbbbbbbbbbb/issues/7

I only saw this problem in Chrome (okay I didn't test in IE or Opera). Not sure why it's not scrolling properly on that first go, but this at least makes sure it is scrolled properly when the dust settles after the first insert of all the chat messages.