### PR TITLE
don't wrap deck table on huge screens

### DIFF
--- a/app/templates/deck/build.hbs
+++ b/app/templates/deck/build.hbs
@@ -15,7 +15,7 @@
     {{/paper-card}}
   </div>
   <div>
-    <div class="col-sm-7">
+    <div class="col-sm-7 col-lg-6">
       {{#full-height classNames="overflow-y-scroll pl-10 pr-10"}}
         {{#paper-card class="mr-0 ml-0"}}
           {{#paper-card-content}}


### PR DESCRIPTION
For issue https://github.com/SirZach/bbbbbbbbbbbbbbb/issues/102. When the filters become sticky on big screens, the other columns were adding up to more than 12.