### PR TITLE
don't use cached deck list when switching back to the decks page

### DIFF
--- a/app/routes/decks.js
+++ b/app/routes/decks.js
@@ -27,11 +27,9 @@ export default Ember.Route.extend({
       });
     }
 
-    // Load all decks, not just mine.
-    var unfilteredDecks = this.get('_unfilteredDecks');
-    if (unfilteredDecks && unfilteredDecks.length) {
-      return unfilteredDecks;
-    }
+    // Load all decks, not just mine. Ensure we don't have old stuff cached.
+    this.set('_lastDeckId');
+    this.set('_unfilteredDecks');
     return this._createFetchPromise();
   },
 


### PR DESCRIPTION
I was too aggressive with caching decks before and it caused you to not see the deck you just created.

Addresses issue #147.