### PR TITLE
work around an ember 1.13.2 regression

### DIFF
--- a/app/templates/components/sample-draw-chart.hbs
+++ b/app/templates/components/sample-draw-chart.hbs
@@ -2,7 +2,7 @@
   {{!-- The cards --}}
   <div class="sample-draw-chart-card-filler">
     <div class="sample-draw-chart-fullscreen-wrapper {{if fullscreen 'is-fullscreen'}}">
-      {{#each sortedHand as |card index|}}
+      {{#each sortedHand key="@index" as |card index|}}
         <div class="card-spoiler card-spoiler-sample-hand card-spoiler-sample-hand-{{index}}">
           <img src={{card.imageUrl}} />
         </div>


### PR DESCRIPTION
Explicitly setting an `{{each}}` key per https://github.com/emberjs/ember.js/pull/11525. This allows the sample hand widget to properly render.