### PR TITLE
replaceWith instead of transitionTo in the index route redirect

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -8,6 +8,6 @@ export default Ember.Route.extend({
       destination = 'decks.list';
     }
 
-    this.transitionTo(destination);
+    this.replaceWith(destination);
   }
 });


### PR DESCRIPTION
Addresses https://github.com/SirZach/bbbbbbbbbbbbbbb/issues/192.

I think there might be some other areas we should be using `replaceWith`, but this was probably the biggest one.