### PR TITLE
move card shadows down a level in the markup

### DIFF
--- a/app/styles/components/game-card.scss
+++ b/app/styles/components/game-card.scss
@@ -3,14 +3,15 @@
   margin: 5px;
   height: 139px;
   width: 100px;
-  box-shadow: 3px 3px 2px 0 map-get($color-grey, '500');
 }
 
 .game-card {
   height: 139px;
-  transition: 0.15s ease-in-out;
-  background-color: map-get($color-red, '300');
   width: 100px;
+  background-color: map-get($color-red, '300');
+  transition: 0.15s ease-in-out;
+  box-shadow: 3px 3px 2px 0 map-get($color-grey, '500');
+
   img {
     width: 100px;
     height: 100%;


### PR DESCRIPTION
Puts the box shadow on the card div instead of the container.