### PR TITLE
deck list page title

### DIFF
--- a/app/controllers/decks/list.js
+++ b/app/controllers/decks/list.js
@@ -9,6 +9,12 @@ export default Ember.Controller.extend({
   /** @property {Boolean} Showing only my decks? */
   filterMineOnly: Ember.computed.alias('controllers.decks.mine'),
 
+  /** @property {String} Title to show in the toolbar. */
+  pageTitle: Ember.computed('controllers.decks.mine', function () {
+    var mine = this.get('controllers.decks.mine');
+    return mine ? 'My Decks' : 'Everybody\'s Decks';
+  }),
+
   actions: {
     toggleFiltersActive: function () {
       this.toggleProperty('filtersActive');

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -198,3 +198,8 @@ body { background-color: map-get($color-grey, '300');}
     }
   }
 }
+
+.toolbar-title {
+  display: inline-block;
+  margin-right: 10px;
+}

--- a/app/templates/nav-toolbars/decks-list.hbs
+++ b/app/templates/nav-toolbars/decks-list.hbs
@@ -1,3 +1,5 @@
+<h3 class="toolbar-title">{{pageTitle}}</h3>
+
 {{paper-button classNames="sm-display" action="toggleFiltersActive" label="Toggle Filters"}}
 
 {{paper-button action="createNewDeck" label="Create"}}


### PR DESCRIPTION
What do you think of this approach? It shows "My Decks" or "Everybody's Decks" in the upper toolbar depending on the settings toggle. Addresses `decks list page should be titled` of #197.