### PR TITLE
Save deck image during edit; use instead of computed property

### DIFF
--- a/app/components/deck-option.js
+++ b/app/components/deck-option.js
@@ -9,8 +9,8 @@ export default Component.extend({
   classNameBindings: [':deck-option', 'isSelected:deck-option-selected'],
   attributeBindings: ['style'],
 
-  style: computed('deck.defaultImageUrl', function() {
-    return `background-image: url("${this.get('deck.defaultImageUrl')}")`;
+  style: computed('deck.imageUrl', function() {
+    return `background-image: url("${this.get('deck.imageUrl')}")`;
   }),
 
   /** @property {Boolean} Is this the selected deck? */

--- a/app/components/deck-option.js
+++ b/app/components/deck-option.js
@@ -10,7 +10,7 @@ export default Component.extend({
   attributeBindings: ['style'],
 
   style: computed('deck.imageUrl', function() {
-    return `background-image: url("${this.get('deck.imageUrl')}")`;
+    return new Ember.Handlebars.SafeString(`background-image: url("${this.get('deck.imageUrl')}")`);
   }),
 
   /** @property {Boolean} Is this the selected deck? */

--- a/app/controllers/deck/build.js
+++ b/app/controllers/deck/build.js
@@ -26,13 +26,15 @@ export default Ember.Controller.extend({
   }.property('model.cardGroups.[]'),
 
   /** @property {String} - url of most expensive cmc card in the deck */
-  defaultImageUrl: Ember.computed('model.mainCardGroups.@each.cmc', function() {
-    let cardGroups = this.get('model.mainCardGroups');
-    if (!cardGroups || !cardGroups.length) {
-      return 'http://big-furry-monster.herokuapp.com/images/default';
+  defaultImageUrl: Ember.computed('model.mainCardGroups.@each.card.cmc',
+    function() {
+      let cardGroups = this.get('model.mainCardGroups');
+      if (!cardGroups || !cardGroups.length) {
+        return 'http://big-furry-monster.herokuapp.com/images/default';
+      }
+      return cardGroups.sortBy('card.cmc').get('lastObject.card.imageUrl');
     }
-    return cardGroups.sortBy('card.cmc').get('lastObject.card.imageUrl');
-  }),
+  ),
 
   actions: {
     toggleFiltersActive() {

--- a/app/controllers/deck/build.js
+++ b/app/controllers/deck/build.js
@@ -25,6 +25,15 @@ export default Ember.Controller.extend({
     return this.get('model.cardGroups.length');
   }.property('model.cardGroups.[]'),
 
+  /** @property {String} - url of most expensive cmc card in the deck */
+  defaultImageUrl: Ember.computed('model.mainCardGroups.@each.cmc', function() {
+    let cardGroups = this.get('model.mainCardGroups');
+    if (!cardGroups || !cardGroups.length) {
+      return 'http://big-furry-monster.herokuapp.com/images/default';
+    }
+    return cardGroups.sortBy('card.cmc').get('lastObject.card.imageUrl');
+  }),
+
   actions: {
     toggleFiltersActive() {
       this.toggleProperty('filtersActive');

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -69,7 +69,7 @@ export default DS.Model.extend({
     if (ENV.environment === 'development') {
       host = 'http://localhost:3000';
     }
-    return `${host}/images/${name}`;
+    return encodeURI(`${host}/images/${name}`);
   }.property('name'),
 
   channelFireballPrice: function() {

--- a/app/models/deck.js
+++ b/app/models/deck.js
@@ -53,6 +53,9 @@ let Deck = DS.Model.extend({
   /** @property {String} - the deck name */
   name: DS.attr('string'),
 
+  /** @property {String} - url of the associated image */
+  imageUrl: DS.attr('string'),
+
   /** @property {String} - user defined comments about the deck */
   comments: DS.attr('string'),
 
@@ -287,17 +290,9 @@ let Deck = DS.Model.extend({
   /** @property {Boolean} - is this deck game-ready? */
   isGameReady: Ember.computed.gt('mainCount', 0),
 
-  /** @property {String} - default image url; uses a card in the deck */
-  defaultImageUrl: function() {
-    let cardGroups = this.get('mainCardGroups');
-    return cardGroups.filterBy('card.mainType', 'Creature')
-      .sortBy('card.cmc')
-      .get('lastObject.card.imageUrl');
-  }.property('mainCardGroups.@each.cmc'),
-
-  defaultImageUrlStyle: computed('defaultImageUrl', function() {
-    let defaultImageUrl = get(this, 'defaultImageUrl');
-    return new Ember.Handlebars.SafeString(`background-image: url(${defaultImageUrl})`);
+  imageUrlStyle: computed('imageUrl', function() {
+    let imageUrl = get(this, 'imageUrl');
+    return new Ember.Handlebars.SafeString(`background-image: url(${imageUrl})`);
   })
 });
 

--- a/app/routes/deck.js
+++ b/app/routes/deck.js
@@ -40,6 +40,13 @@ export default Ember.Route.extend({
     return Ember.RSVP.all(cardPromiseArray);
   },
 
+  /** Get the default image url for the deck and set it as the imageUrl. */
+  applyDefaultImageUrlToDeck(deck) {
+    let buildController = this.controllerFor('deck.build');
+    let imageUrl = buildController.get('defaultImageUrl');
+    deck.set('imageUrl', imageUrl);
+  },
+
   actions: {
     addToMain(card) {
       this.get('controller.model').addCard(card, 'main');
@@ -50,6 +57,8 @@ export default Ember.Route.extend({
     },
 
     saveDeck(deck) {
+      this.applyDefaultImageUrlToDeck(deck);
+
       this.get('session.user').then((user) => {
         deck.save()
           .then(() => user.get('decks'))

--- a/app/templates/components/deck-listing.hbs
+++ b/app/templates/components/deck-listing.hbs
@@ -1,4 +1,4 @@
-<img src={{deck.defaultImageUrl}} class="md-avatar">
+<img src={{deck.imageUrl}} class="md-avatar">
 <div class="md-list-item-text">
   {{!--
   {{#link-to 'deck.index' deck tagName="h3" class="link"}}{{deck.name}}{{/link-to}}

--- a/app/templates/deck/index.hbs
+++ b/app/templates/deck/index.hbs
@@ -1,5 +1,5 @@
 {{#paper-item classNames="deck-header bg-transparent"}}
-  <div class="deck-image-frame" style={{model.defaultImageUrlStyle}}></div>
+  <div class="deck-image-frame" style={{model.imageUrlStyle}}></div>
 
   <div class="md-list-item-text">
     <h2>{{model.name}}</h2>

--- a/app/templates/decks/list.hbs
+++ b/app/templates/decks/list.hbs
@@ -22,7 +22,7 @@
               deleteDeck="deleteDeck"
               goToDeckBuilder="goToDeckBuilder"}} --}}
               {{#paper-item class="md-3-line"}}
-                <div class="deck-image-frame" style={{deck.defaultImageUrlStyle}}></div>
+                <div class="deck-image-frame" style={{deck.imageUrlStyle}}></div>
                 <div class="md-list-item-text">
 
                   {{#link-to 'deck.index' deck tagName="h3" class="link"}}{{deck.name}}{{/link-to}}

--- a/tests/unit/controllers/deck/build-test.js
+++ b/tests/unit/controllers/deck/build-test.js
@@ -1,0 +1,25 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:deck/build');
+
+test('defaultImageUrl is from the most expensive card', function(assert) {
+  let controller = this.subject({
+    model: Ember.Object.create({
+      mainCardGroups: [{
+        card: {
+          cmc: 2,
+          imageUrl: '/Titanic%20Growth'
+        }
+      }, {
+        card: {
+          cmc: 1,
+          imageUrl: '/Giant%20Growth'
+        }
+      }]
+    })
+  });
+
+  let result = controller.get('defaultImageUrl');
+
+  assert.equal(result, '/Titanic%20Growth');
+});

--- a/tests/unit/controllers/deck/build-test.js
+++ b/tests/unit/controllers/deck/build-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:deck/build');
@@ -22,4 +23,13 @@ test('defaultImageUrl is from the most expensive card', function(assert) {
   let result = controller.get('defaultImageUrl');
 
   assert.equal(result, '/Titanic%20Growth');
+});
+
+test('defaultImageUrl is default if no cards', function(assert) {
+  let controller = this.subject();
+
+  let result = controller.get('defaultImageUrl');
+
+  assert.equal(result,
+    'http://big-furry-monster.herokuapp.com/images/default');
 });


### PR DESCRIPTION
Removes the computed deck image property that had to download all the cards in the deck before it could determine the image to use.

It now saves the deck image as the image of the most expensive converted mana cost card. Maybe in the future we can enable a deck image setting if people don't like the image that shows up.

Depends upon https://github.com/SirZach/bfm/pull/8.